### PR TITLE
Fix: upgrade to NVD JSON 2.0 Data Feeds

### DIFF
--- a/scripts/create-json-files
+++ b/scripts/create-json-files
@@ -8,9 +8,9 @@ abort "usage: $0 [<output_dir>] < <cve_json_file> " if ARGV.size > 1
 outdir = (ARGV.empty? ? Dir.pwd : ARGV[0])
 FileUtils.mkdir_p(outdir)
 
-cves = JSON.load(STDIN.read)["CVE_Items"]
+cves = JSON.load(STDIN.read)["vulnerabilities"]
 
 cves.each do |cve|
-  id = cve["cve"]["CVE_data_meta"]["ID"]
-  File.write(File.join(outdir, "#{id}.json"), JSON.pretty_generate(cve))
+  id = cve["cve"]["id"]
+  File.write(File.join(outdir, "#{id}.json"), JSON.pretty_generate(cve["cve"]))
 end

--- a/scripts/fetch-and-update
+++ b/scripts/fetch-and-update
@@ -2,14 +2,15 @@
 
 set -euxo pipefail
 
-CVE_BASE_URL="https://nvd.nist.gov/feeds/json/cve/1.1"
+CVE_BASE_URL="https://nvd.nist.gov/feeds/json/cve/2.0"
 
 CURDIR=$(dirname `type -p $0`)
 LICENSE_FILE=$CURDIR/../LICENSE
 
 function fetch_and_update {
-	meta_file_url="${CVE_BASE_URL}/nvdcve-1.1-${2}.meta"
-	json_file_url="${CVE_BASE_URL}/nvdcve-1.1-${2}.json.gz"
+	meta_file_url="${CVE_BASE_URL}/nvdcve-2.0-${2}.meta"
+	json_file_url="${CVE_BASE_URL}/nvdcve-2.0-${2}.json.gz"
+
 
 	cve_file=$(mktemp)
 	trap "rm -f $cve_file" INT TERM EXIT


### PR DESCRIPTION
It seems that the 1.1 feeds are not maintained anymore. This change upgrade to use the 2.0 feeds instead.

See https://nvd.nist.gov/vuln/data-feeds .